### PR TITLE
Add concurrency to sideqik

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,4 @@
+:concurrency: 25
 :queues:
   - ["mailers", 2]
   - ["newsletter", 1]


### PR DESCRIPTION
Set `:concurrency` in `sideqik.yml` to 25 instead of the default 10.