### PR TITLE
Switch decidim-term_customizer to the openpoke maintained fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "decidim-conferences", DECIDIM_VERSION
 
 gem "decidim-decidim_awesome", "~> 0.12.3"
 gem "decidim-direct_verifications", git: "https://github.com/Platoniq/decidim-verifications-direct_verifications", branch: "main"
-gem "decidim-term_customizer", git: "https://github.com/Platoniq/decidim-module-term_customizer", branch: "master"
+gem "decidim-term_customizer", github: "openpoke/decidim-module-term_customizer", branch: "release/0.29-stable"
 
 gem "appsignal"
 gem "bootsnap", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/Platoniq/decidim-module-term_customizer
-  revision: 3da4973f52649534fa9cc2acaaa4d89176a19351
-  branch: master
-  specs:
-    decidim-term_customizer (0.29.0)
-      decidim-admin (~> 0.29.0)
-      decidim-core (~> 0.29.0)
-
-GIT
   remote: https://github.com/Platoniq/decidim-verifications-direct_verifications
   revision: 6e4106812d82f1f717ad848b04b6ea59569ebcb9
   branch: main
@@ -16,6 +7,15 @@ GIT
       decidim-admin (>= 0.29.0, < 0.30)
       decidim-core (>= 0.29.0, < 0.30)
       deface (~> 1.5)
+
+GIT
+  remote: https://github.com/openpoke/decidim-module-term_customizer.git
+  revision: 12d3c4f09e0a136e3d5533966c0d983edbb02564
+  branch: release/0.29-stable
+  specs:
+    decidim-term_customizer (0.29.1)
+      decidim-admin (~> 0.29.0)
+      decidim-core (~> 0.29.0)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
## Summary
- Was pinned to Platoniq's own fork of `decidim-term_customizer` (branch `master`), which has fallen behind.
- `openpoke/decidim-module-term_customizer` actively maintains a `release/0.29-stable` branch matching this app's Decidim 0.29.4, so we can depend on their upkeep instead of patching our own fork.

## Verification
- `bundle install` resolves cleanly against the new source.
- `bin/rails decidim:upgrade` + `bin/rails db:migrate` against a schema-loaded local database produce no new/changed migrations (same Decidim compat range, just a different upstream).
- Note: replaying this app's full migration history from empty hits an unrelated, pre-existing gap in a 2018 core-Decidim migration -- `schema:load` sidesteps it, same as any fresh dev setup would need to.

## Test plan
- [x] `bundle install`
- [x] `bin/rails decidim:upgrade`
- [x] `bin/rails db:migrate`
- [x] Smoke-test term customizer admin screens